### PR TITLE
Fix compatibility for Atom 0.210

### DIFF
--- a/keymaps/hashy.cson
+++ b/keymaps/hashy.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'.atom-workspace':
   'ctrl-alt-h': 'hashy:convert'

--- a/lib/hashy.coffee
+++ b/lib/hashy.coffee
@@ -1,10 +1,10 @@
 module.exports =
   activate: ->
-    atom.workspaceView.command "hashy:convert", => @convert()
+    atom.commands.add "atom-workspace", "hashy:convert", => @convert()
 
   convert: ->
-    editor = atom.workspace.activePaneItem
-    selection = editor.getSelection().getText()
+    editor = atom.workspace.getActiveTextEditor()
+    selection = editor.getSelectedText()
     replace_reg_exp = new RegExp(":([a-z_\d]+) =>","g")
     replacement = selection.replace(replace_reg_exp,"$1:")
 

--- a/menus/hashy.cson
+++ b/menus/hashy.cson
@@ -1,6 +1,7 @@
 'context-menu':
-  '.overlayer':
-      'Convert hashes': 'hashy:convert'
+  '.overlayer': [
+    { 'label': 'Convert hashes', 'command': 'hashy:convert' }
+  ]
 
 'menu': [
   {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "main": "./lib/hashy",
   "version": "1.0.0",
   "description": "Convert Ruby 1.8 hash style",
-  "activationEvents": [
-    "hashy:convert"
-  ],
+  "activationCommands": {
+    "atom-workspace": ["hashy:convert"]
+  },
   "repository": "https://github.com/jankeesvw/hashy",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This makes hashy compatible with the current Atom API and fixes #1 and #2.
