### PR TITLE
Ignore spaces around rocket

### DIFF
--- a/lib/hashy.coffee
+++ b/lib/hashy.coffee
@@ -5,7 +5,7 @@ module.exports =
   convert: ->
     editor = atom.workspace.getActiveTextEditor()
     selection = editor.getSelectedText()
-    replace_reg_exp = new RegExp(":([a-z_\d]+) =>","g")
-    replacement = selection.replace(replace_reg_exp,"$1:")
+    replace_reg_exp = new RegExp(":([a-z_\d]+)\s*=>\s*","g")
+    replacement = selection.replace(replace_reg_exp,"$1: ")
 
     editor.insertText(replacement)


### PR DESCRIPTION
Use a more robust regex which accounts for condensed and expanded rocket notation (ignore spaces surrounding rocket).
